### PR TITLE
Update .editorconfig to follow PSR-2 in PHP files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,11 +5,11 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
-indent_size = 2
+indent_size = 4
 trim_trailing_whitespace = true
 
 [*.md]
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 
-[*.{yml,yaml}]
+[*.{yml,yaml,js,vue,blade.php,scss}]
 indent_size = 2


### PR DESCRIPTION
PHP files should follow PSR-2 with 4 space indenting: https://www.php-fig.org/psr/psr-2/#24-indenting

JS and other font-end related files can follow the JavaScript de facto standard of 2 spaces indent.