### PR TITLE
Update .htaccess to use php 7.4

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,5 @@
 AddDefaultCharset utf-8
+AddHandler application/x-httpd-ea-php74 .php
 Options +FollowSymLinks -Indexes
 
 RewriteEngine on

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,3 +1,4 @@
+AddHandler application/x-httpd-ea-php74 .php
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews -Indexes


### PR DESCRIPTION
CPanel is apparently parsing our htaccess files and when it detects one it will rewrite the php config for a site with the "appropriate" php version.
In reality it disgregards the php version setting for the site in question when presented with our current .htaccess files.
To combat the need to always enter cpanel and set php version 7.4 when using 7.4 features, this pr adds a line which makes multiphp manager set the version to 7.4
